### PR TITLE
Add example specs for a Mongo cluster

### DIFF
--- a/apps/mongoCluster.yml
+++ b/apps/mongoCluster.yml
@@ -1,0 +1,31 @@
+# This app provides an entrypoint into the set of mongoCluster
+# node containers. This allows us to provide a single reference
+# that ends up depending on all of the component containers so
+# that Dusty knows to run them.
+
+image: mongo:3.0.4
+
+depends:
+  apps:
+    - mongoCluster1
+    - mongoCluster2
+    - mongoCluster3
+
+commands:
+  always:
+    - sleep infinity
+
+scripts:
+  - name: initialize
+    description: Initialize the Mongo cluster for the first time
+    command:
+      - |
+        mongo --host mongoCluster1 --port 27018 --eval "printjson(rs.initiate({_id: 'dusty', members: [{_id: 0, host: 'localhost:27018'}]}));"
+      - mongo --host mongoCluster1 --port 27018 --eval "printjson(rs.add('localhost:27019'));"
+      - mongo --host mongoCluster1 --port 27018 --eval "printjson(rs.add('localhost:27020'));"
+      - echo "Cluster should be configured, printing rs.status()"
+      - mongo --host mongoCluster1 --port 27018 --eval "printjson(rs.status());"
+  - name: shell
+    description: Connect a mongo shell to the primary
+    command:
+      - mongo --host mongoCluster1 --port 27018

--- a/apps/mongoCluster1.yml
+++ b/apps/mongoCluster1.yml
@@ -1,0 +1,20 @@
+image: mongo:3.0.4
+
+commands:
+  always:
+    - mongod --replSet dusty --port 27018 --smallfiles --oplogSize 128
+
+scripts:
+  - name: initialize
+    description: Initialize the Mongo cluster for the first time
+    command:
+      - |
+        mongo --port 27018 --eval "printjson(rs.initiate({_id: 'dusty', members: [{_id: 0, host: 'localhost:27018'}]}));"
+      - mongo --port 27018 --eval "printjson(rs.add('localhost:27019'));"
+      - mongo --port 27018 --eval "printjson(rs.add('localhost:27020'));"
+      - echo "Cluster should be configured, printing rs.status()"
+      - mongo --port 27018 --eval "printjson(rs.status());"
+  - name: shell
+    description: Connect a mongo shell to the primary
+    command:
+      - mongo --port 27018

--- a/apps/mongoCluster1.yml
+++ b/apps/mongoCluster1.yml
@@ -3,18 +3,3 @@ image: mongo:3.0.4
 commands:
   always:
     - mongod --replSet dusty --port 27018 --smallfiles --oplogSize 128
-
-scripts:
-  - name: initialize
-    description: Initialize the Mongo cluster for the first time
-    command:
-      - |
-        mongo --port 27018 --eval "printjson(rs.initiate({_id: 'dusty', members: [{_id: 0, host: 'localhost:27018'}]}));"
-      - mongo --port 27018 --eval "printjson(rs.add('localhost:27019'));"
-      - mongo --port 27018 --eval "printjson(rs.add('localhost:27020'));"
-      - echo "Cluster should be configured, printing rs.status()"
-      - mongo --port 27018 --eval "printjson(rs.status());"
-  - name: shell
-    description: Connect a mongo shell to the primary
-    command:
-      - mongo --port 27018

--- a/apps/mongoCluster2.yml
+++ b/apps/mongoCluster2.yml
@@ -1,0 +1,8 @@
+image: mongo:3.0.4
+
+commands:
+  always:
+    - mongod --replSet dusty --port 27019 --smallfiles --oplogSize 128
+
+compose:
+  net: container:mongoCluster1

--- a/apps/mongoCluster3.yml
+++ b/apps/mongoCluster3.yml
@@ -5,4 +5,4 @@ commands:
     - mongod --replSet dusty --port 27020 --smallfiles --oplogSize 128
 
 compose:
-  net: container:mongoCluster2
+  net: container:mongoCluster1

--- a/apps/mongoCluster3.yml
+++ b/apps/mongoCluster3.yml
@@ -1,0 +1,8 @@
+image: mongo:3.0.4
+
+commands:
+  always:
+    - mongod --replSet dusty --port 27020 --smallfiles --oplogSize 128
+
+compose:
+  net: container:mongoCluster2

--- a/bundles/mongo-cluster.yml
+++ b/bundles/mongo-cluster.yml
@@ -1,0 +1,5 @@
+description: Run a Mongo replica set by using container network daisy-chaining
+apps:
+  - mongoCluster1
+  - mongoCluster2
+  - mongoCluster3

--- a/bundles/mongo-cluster.yml
+++ b/bundles/mongo-cluster.yml
@@ -1,5 +1,3 @@
 description: Run a Mongo replica set by using container network daisy-chaining
 apps:
-  - mongoCluster1
-  - mongoCluster2
-  - mongoCluster3
+  - mongoCluster


### PR DESCRIPTION
@jsingle @elubow

These specs illustrate the idea of using container network daisy-chaining to get around the lack of bidirectional links in Docker. Three Mongo containers are defined separately, and connected to each other using the `net` key of `compose`. This tells Compose that the containers should share the same network stack. We can then connect the nodes at runtime without any additional IP discovery because they can all see each other on `localhost`.

There are a couple peculiarities with this pattern:
1. Since our dependency DAG navigation is based entirely on `depends`, Dusty can't tell right now that these containers need each other to be running. To get around that, you need to specify them all in the bundle. We could make Dusty read the `net` key and incorporate that into the DAG.
2. Dependent services should be able to add `mongoCluster1` to their `depends` and reach all the nodes on their separate ports through the `mongoCluster1` link.
3. This approach won't work if the processes you're bidirectionally linking must run on the same port.
